### PR TITLE
Remove return from module

### DIFF
--- a/lib/best_in_place/check_version.rb
+++ b/lib/best_in_place/check_version.rb
@@ -2,7 +2,6 @@ module BestInPlace
   module CheckVersion
     if Rails::VERSION::STRING < "3.1"
       raise "This version of Best in Place is intended to be used for Rails >= 3.1. If you want to use it with Rails 3.0 or lower, please use the rails-3.0 branch."
-      return
     end
   end
 end


### PR DESCRIPTION
```
f4b9b6af7d54:/app# rails s
Traceback (most recent call last):
        20: from bin/rails:4:in `<main>'
        19: from bin/rails:4:in `require'
        18: from /usr/lib/ruby/gems/2.5.0/gems/railties-4.2.11.1/lib/rails/commands.rb:17:in `<top (required)>'
        17: from /usr/lib/ruby/gems/2.5.0/gems/railties-4.2.11.1/lib/rails/commands/commands_tasks.rb:39:in `run_command!'
        16: from /usr/lib/ruby/gems/2.5.0/gems/railties-4.2.11.1/lib/rails/commands/commands_tasks.rb:75:in `server'
        15: from /usr/lib/ruby/gems/2.5.0/gems/railties-4.2.11.1/lib/rails/commands/commands_tasks.rb:75:in `tap'
        14: from /usr/lib/ruby/gems/2.5.0/gems/railties-4.2.11.1/lib/rails/commands/commands_tasks.rb:78:in `block in server'
        13: from /usr/lib/ruby/gems/2.5.0/gems/railties-4.2.11.1/lib/rails/commands/commands_tasks.rb:78:in `require'
        12: from /app/config/application.rb:6:in `<top (required)>'
        11: from /usr/local/lib/site_ruby/2.5.0/bundler.rb:114:in `require'
        10: from /usr/local/lib/site_ruby/2.5.0/bundler/runtime.rb:65:in `require'
         9: from /usr/local/lib/site_ruby/2.5.0/bundler/runtime.rb:65:in `each'
         8: from /usr/local/lib/site_ruby/2.5.0/bundler/runtime.rb:76:in `block in require'
         7: from /usr/local/lib/site_ruby/2.5.0/bundler/runtime.rb:76:in `each'
         6: from /usr/local/lib/site_ruby/2.5.0/bundler/runtime.rb:81:in `block (2 levels) in require'
         5: from /usr/local/lib/site_ruby/2.5.0/bundler/runtime.rb:81:in `require'
         4: from /usr/lib/ruby/gems/2.5.0/bundler/gems/best_in_place-e5b1e44405ac/lib/best_in_place.rb:1:in `<top (required)>'
         3: from /usr/lib/ruby/gems/2.5.0/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:274:in `require'
         2: from /usr/lib/ruby/gems/2.5.0/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:240:in `load_dependency'
         1: from /usr/lib/ruby/gems/2.5.0/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:274:in `block in require'
/usr/lib/ruby/gems/2.5.0/gems/activesupport-4.2.11.1/lib/active_support/dependencies.rb:274:in `require': /usr/lib/ruby/gems/2.5.0/bundler/gems/best_in_place-e5b1e44405ac/lib/best_in_place/check_version.rb:5: Invalid return in class/module body (SyntaxError)
      return
      ^~~~~~
```