### PR TITLE
Fix compatibility with newer rails

### DIFF
--- a/lib/best_in_place/railtie.rb
+++ b/lib/best_in_place/railtie.rb
@@ -1,7 +1,7 @@
 module BestInPlace
   class Railtie < Rails::Railtie
     config.after_initialize do
-      BestInPlace::ViewHelpers = ActionView::Base.new
+      BestInPlace::ViewHelpers = ActionView::Base.empty
     end
   end
 end


### PR DESCRIPTION
ActionView 6.1.4 doesn't allow to create empty instance of `ActionView::Base` anymore. Because of it was decided to use `.empty` method provided by `ActionView::Base` class